### PR TITLE
NOT READY FOR MERGE: Start on restructure of module to allow for instances + adding tests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,117 +1,44 @@
 'use strict';
 
 
-
+//
 // Dependencies
 //
-var  request = require('request');
 
+var request = require('request');
+var Job     = require('./job');
 
-
-// This is a boolean flag that determines if 
-// the worker is busy or free
+// Jobukyu Client
 //
-var idle = true;
-
-
-
-// Used to hold the report error function
+// @param {String} queueUrl default is 'http://localhost:9800'
 //
-var reportError = null;
+var Client = function(queueUrl) {
 
+  this.idle = true;
 
+  // Holds current job instance
+  this.currentJob = null;
 
-// Used to hold the report progress function
-//
-var reportProgress = null;
+  this.jobQueueUrl = queueUrl || 'http://localhost:9800';
 
-
-
-// Used to track the current job, so that it can be 
-// referenced in other places
-//
-var currentJob = null;
-
-
-
-// Used to track the jobQueueUrl
-//
-var jobQueueUrl = 'http://localhost:9800';
-
-
-
-// Sets the job queue url to a new value
-//
-// @url   {String}    The url to set the job queue url to
-// @cb    {Function}  The function to execute once finished
-//
-function setJobQueueUrl (url, cb) {
-  jobQueueUrl = url;
-  cb();
-}
-
-
-
-// This defines the function for reporting progress
-// 
-// @job     {Object}    The job record
-//
-function defineProgress (job) {
-  reportProgress = function (progress) {
-    var url = job.webhooks.processing[0].url;
-    request.put({url: url, body: {progress: progress}, json: true}, function (err) {
-      if (err) {
-        reportError(err);
-      }
-    });
-  };
-  return reportProgress;
-}
-
-
-
-// This defines the function for reporting an error
-// 
-// @job     {Object}    The job record
-//
-function defineError (job, cb) {
-  reportError = function (err) {
-    job.metadata.dataToSendWhenFailed.progress.data = err;
-    request.put({url: jobQueueUrl + '/jobs/' + job._id + '/fail', body: {job: job}, json: true}, function () {
-      request.put({url: jobQueueUrl + '/jobs/' + job._id + '/release', json: true}, function () {
-        if (cb && typeof cb === 'function') {
-          cb(err);
-        } else {
-          console.log(err);
-          process.exit(1);
-        }
-      });
-    });
-  };
-
-  return reportError;
-}
-
+  return this;
+};
 
 
 // Finds any jobs on the queue that are available
 //
 // @cb    {Function}  The function to execute once finished
 //
-function findAvailableJob (jobType, cb) {
+Client.prototype.findAvailableJob = function (jobType, cb) {
   var url, query;
 
   if (jobType) {
-    url     = jobQueueUrl + '/jobs/search';
+    url     = this.jobQueueUrl + '/jobs/search';
     query   = {status: 'new', type: jobType};
   } else {
-    url     = jobQueueUrl + '/jobs/new';
+    url     = this.jobQueueUrl + '/jobs/new';
   }
 
-  // for now, we assume that all jobs are Process PDF
-  // once we support upload to S3 jobs, then we'll need to inspect the job's type
-  // in the list.
-  //
   var conditions = {url: url, json: true};
   if (query) {conditions.qs = query;}
 
@@ -120,7 +47,7 @@ function findAvailableJob (jobType, cb) {
       cb(err, null);
     } else {
       if (body && body.length > 0) {
-        cb(err, body[0]);
+        cb(err, new Job(body[0]));
       } else {
         cb(err, null);
       }
@@ -129,65 +56,19 @@ function findAvailableJob (jobType, cb) {
 }
 
 
-
-// Takes a job from the queue
-//
-// @job   {Object}    The job record
-// @cb    {Function}  The function to execute once finished
-//
-function takeJob (job, cb) {
-  request.put({url: jobQueueUrl + '/jobs/' + job._id + '/take', json: true}, function (err, res, body) {
-    if (err) {
-      cb(err);
-    } else {
-      if (res.statusCode !== 201) {
-        cb(new Error(body));
-      } else {
-        defineError(job);
-        defineProgress(job);
-        currentJob = job;
-        cb(null);
-      }
-    }
-  });
-}
-
-
-
-// Completes the job
-//
-// @job   {Object}    The job record
-// @cb    {Function}  The function to execute once finished
-//
-function completeJob (job, cb) {
-  request.put({url: jobQueueUrl + '/jobs/' + job._id + '/complete', body: {job: job}, json: true}, function (err, res, body) {
-    if (err) {
-      cb(err);
-    } else {
-      if (res.statusCode !== 201) {
-        cb(new Error(body));
-      } else {
-        cb(null);
-      }
-    }
-  });
-}
-
-
-
 // Gets a job from the job queue server
 //
 // @jobType     {String}    The job type to fetch
 // @cb          {Function}  The function to execute once finished
 //
-function getJobFromQueue (jobType, cb) {
-
-  if (idle) {
-    findAvailableJob(jobType, function(err, job) {
+Client.prototype.getJobFromQueue =  function (jobType, cb) {
+  var self = this;
+  if (self.idle) {
+    self.findAvailableJob(jobType, function(err, job) {
       if (err === null && job !== null) {
-        takeJob(job, function (err) {
+        self.takeJob(job, function (err) {
           if (err === null) {
-            idle = false;
+            self.idle = false;
             cb(job);
           }
         });
@@ -198,12 +79,19 @@ function getJobFromQueue (jobType, cb) {
 }
 
 
-
-// Frees the worker
+// Sets the Client to idle (for when in use as a worker)
 //
-function free () {
-  idle = true;
-}
+// @return {Boolean} this.idle's new results (always true)
+//
+Client.prototype.free = function() {
+  return this.idle = true;
+};
+
+
+
+var createClient = function(queueUrl) {
+  return new Client(queueUrl);
+};
 
 
 
@@ -217,11 +105,6 @@ function free () {
 
 // Expose the public API
 //
-module.exports = {
-  setJobQueueUrl  : setJobQueueUrl,
-  completeJob     : completeJob,
-  getJobFromQueue : getJobFromQueue,
-  defineError     : defineError,
-  defineProgress  : defineProgress,
-  free            : free
-};
+module.exports        = createClient;
+module.exports.Client = Client;
+module.exports.Job    = Job;

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,7 @@
 // Dependencies
 //
 
-var request = require('request');
+var request = require('./request');
 var Job     = require('./job');
 
 // Jobukyu Client
@@ -53,7 +53,7 @@ Client.prototype.findAvailableJob = function (jobType, cb) {
       }
     }
   });
-}
+};
 
 
 // Gets a job from the job queue server
@@ -75,8 +75,7 @@ Client.prototype.getJobFromQueue =  function (jobType, cb) {
       }
     });
   }
-
-}
+};
 
 
 // Sets the Client to idle (for when in use as a worker)
@@ -84,7 +83,8 @@ Client.prototype.getJobFromQueue =  function (jobType, cb) {
 // @return {Boolean} this.idle's new results (always true)
 //
 Client.prototype.free = function() {
-  return this.idle = true;
+  this.idle = true;
+  return this.idle;
 };
 
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,0 +1,88 @@
+
+var Job = function(jobData, client) {
+  this.data   = jobData;
+  this.client = client;
+  return this;
+};
+
+Job.prototype.url = function() {
+  return this.client.jobQueueUrl + '/jobs/' + this.data._id;
+};
+
+// Takes a job from the queue
+//
+// @job   {Object}    The job record
+// @cb    {Function}  The function to execute once finished
+//
+Job.prototype.take = function(cb) {
+  var self = this;
+  request.put(this.url() + '/take', function (err, res, body) {
+    if (err) {
+      cb(err);
+    } else if(res.statusCode !== 201) {
+      cb(new Error(body));
+    } else {
+      this.client.currentJob = self;
+      cb(null);
+    }
+  });
+};
+
+
+Job.prototype.reportProgress = function (progress) {
+  var url = this.data.webhooks.processing[0].url, self = this;
+  request.put({ url: url, body: {progress: progress} }, function (err) {
+    if (err) {
+      self.reportError(err);
+    }
+  });
+};
+
+Job.prototype.reportError = function (err, cb) {
+  var self = this;
+  this.data.metadata.dataToSendWhenFailed.progress.data = err;
+  request.put({ url: this.url() + '/fail', body: { job: this.data } }, function () {
+    request.put(self.url() + '/release', function () {
+      if (cb && typeof cb === 'function') {
+        cb(err);
+      } else {
+        console.log(err);
+        process.exit(1);
+      }
+    });
+  });
+};
+
+
+// Completes the job
+//
+// @job   {Object}    The job record
+// @cb    {Function}  The function to execute once finished
+//
+Job.prototype.complete = function (cb) {
+  request.put({ url: this.url() + '/complete', body: {job: this} }, function (err, res, body) {
+    if (err) {
+      cb(err);
+    } else {
+      if (res.statusCode !== 201) {
+        cb(new Error(body));
+      } else {
+        cb(null);
+      }
+    }
+  });
+}
+
+Job.prototype.generateDone = function() {
+  var self = this;
+  return function(err) {
+    if(err) {
+      self.reportError(err);
+    } else {
+      self.complete()
+    }
+  };
+};
+
+
+module.exports = Job;

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,3 +1,7 @@
+'use strict';
+
+
+var request = require('./request');
 
 var Job = function(jobData, client) {
   this.data   = jobData;
@@ -71,7 +75,7 @@ Job.prototype.complete = function (cb) {
       }
     }
   });
-}
+};
 
 Job.prototype.generateDone = function() {
   var self = this;
@@ -79,7 +83,7 @@ Job.prototype.generateDone = function() {
     if(err) {
       self.reportError(err);
     } else {
-      self.complete()
+      self.complete();
     }
   };
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,2 @@
+
+module.exports = require('request').defaults({ json: true });

--- a/test/client.js
+++ b/test/client.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var assert        = require('assert');
 var jobukyuClient = require('../');
@@ -18,7 +19,6 @@ describe('jobukyu-client', function() {
   describe('Client', function() {
 
     describe('.createJob()', function() {
-      var client = jobukyuClient();
       it('should create a job in the queue');
     });
 

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,75 @@
+
+var assert        = require('assert');
+var jobukyuClient = require('../');
+
+describe('jobukyu-client', function() {
+
+  describe('creating a client', function() {
+    it('should create an instance of Client', function() {
+      assert(jobukyuClient() instanceof jobukyuClient.Client);
+    });
+    it('should accept a url', function() {
+      var queueUrl = 'http://jobqueuehost:2213';
+      var client = jobukyuClient(queueUrl);
+      assert.equal(client.jobQueueUrl, queueUrl);
+    });
+  });
+
+  describe('Client', function() {
+
+    describe('.createJob()', function() {
+      var client = jobukyuClient();
+      it('should create a job in the queue');
+    });
+
+    describe('.findAvailableJob()', function() {
+      it('should provide a null results if not matching jobs');
+      it('should provide a Job instance on matching job');
+    });
+
+    describe('.getJobFromQueue()', function() {
+      it('should provide null if no jobs');
+      it('should provide a Job instance and mark as taken if jobs found');
+    });
+
+    describe('.free()', function() {
+      it('should set client.idle to true', function() {
+        var client = jobukyuClient();
+        client.idle = false;
+        client.free();
+        assert.equal(client.idle, true);
+      });
+    });
+  });
+
+  describe('Job', function() {
+
+    describe('.url()', function() {
+      it('should return the queue url with base job path');
+    });
+
+    describe('.take()', function() {
+      it('should make the job unavailable');
+    });
+
+    describe('.reportProgress()', function() {
+      it('should inform given webhook on progress');
+    });
+
+    describe('.reportError()', function() {
+      it('should inform given webook and queue');
+    });
+
+    describe('.complete()', function() {
+      it('should inform given webook and queue');
+    });
+
+    describe('.generateDone()', function() {
+      it('should return a function');
+      it('should reportError when err given to returned function');
+      it('should reportComplete when no err given to returned function');
+    });
+
+  });
+
+});


### PR DESCRIPTION
I've started work on making the module really friendly! :smiley_cat: 

There's test definitions ( #4 ) and instances ( #7 ) of client in here already.

Aim: No passing around `job` and instead call prototypes of it. e.g instead of 

``` js
var reportProgress = client.defineProgress(job);
reportProgress(50);
// becomes
job.reportProgress(50)
```

Any help getting this implemented quick would be awesome!
